### PR TITLE
Download stanc, setup submodules; use make to do this

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/bin/stanc
+/bin/stanc.exe
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+*~
+
 /bin/stanc
 /bin/stanc.exe
+
 
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "stan"]
+	path = stan
+	url = https://github.com/stan-dev/stan

--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,34 @@ help:
 all:
 	@echo 'all'
 
-install: bin/stanc
-	@echo 'install'
+install: bin/stanc stan/src/stan/version.hpp stan/lib/stan_math/stan/math/version.hpp
+	@echo
+	@echo 'Installation complete' 
 
 uninstall:
 	@echo 'uninstall'
 
 clean:
-	@echo 'clean'
+	$(RM) bin/stanc
 
 check:
 	@echo 'check'
-
 
 
 bin/stanc: OS ?= $(shell uname -s)
 bin/stanc: OS_TAG = $(strip $(if $(filter Darwin,$(OS)), mac, linux))
 bin/stanc: URL = github.com/stan-dev/stanc3/releases/download
 bin/stanc:
+	@echo '* downloading stanc $(STAN_VERSION) for $(OS_TAG)'
+	@echo ''
 	@mkdir -p $(dir $@)
-	curl -L https://$(URL)/$(STAN_VERSION)/$(OS_TAG)-stanc -o $@
-	chmod +x $@
+	@curl -L https://$(URL)/$(STAN_VERSION)/$(OS_TAG)-stanc -o $@
+	@chmod +x $@
+
+
+stan/src/stan/version.hpp:
+	git submodule update --init --depth 1
+
+
+stan/lib/stan_math/stan/math/version.hpp: stan/src/stan/version.hpp
+	cd stan && git submodule update --init --depth 1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+PHONY: help all install uninstall clean check
+
+help:
+	@echo '--------------------------------------------------------------------------------'
+	@echo '--------------------------------------------------------------------------------'
+
+all:
+	@echo 'all'
+
+install:
+	@echo 'install'
+
+uninstall:
+	@echo 'uninstall'
+
+clean:
+	@echo 'clean'
+
+check:
+	@echo 'check'
+

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,23 @@ install: bin/stanc stan/src/stan/version.hpp stan/lib/stan_math/stan/math/versio
 	@echo 'Installation complete' 
 
 uninstall:
+	$(RM) bin/stanc
+	@echo
 	@echo 'uninstall'
 
 clean:
-	$(RM) bin/stanc
+	@echo
+	@echo 'clean'
 
 check:
-	@echo 'check'
+	@ n=0; \
+	test -f bin/stanc || { echo 'Error: bin/stanc does not exist'; ((n++)); } ; \
+	test -f stan/src/stan/version.hpp || { echo 'Error: Stan submodule needs to be updated'; ((n++)); }; \
+	test -f stan/lib/stan_math/stan/math/version.hpp || { echo 'Error: Stan Math submodule needs to be updated'; ((n++)); }; \
+	if [ $$n -gt 0 ]; then echo; echo 'Please run `make install`'; echo; exit 1; fi
+	@echo
+	@echo 'Check: All checks pass'
+
 
 
 bin/stanc: OS ?= $(shell uname -s)
@@ -36,7 +46,6 @@ bin/stanc:
 
 stan/src/stan/version.hpp:
 	git submodule update --init --depth 1
-
 
 stan/lib/stan_math/stan/math/version.hpp: stan/src/stan/version.hpp
 	cd stan && git submodule update --init --depth 1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 PHONY: help all install uninstall clean check
 
+STAN_VERSION=v2.29.0-rc2
+
 help:
 	@echo '--------------------------------------------------------------------------------'
 	@echo '--------------------------------------------------------------------------------'
@@ -7,7 +9,7 @@ help:
 all:
 	@echo 'all'
 
-install:
+install: bin/stanc
 	@echo 'install'
 
 uninstall:
@@ -19,3 +21,12 @@ clean:
 check:
 	@echo 'check'
 
+
+
+bin/stanc: OS ?= $(shell uname -s)
+bin/stanc: OS_TAG = $(strip $(if $(filter Darwin,$(OS)), mac, linux))
+bin/stanc: URL = github.com/stan-dev/stanc3/releases/download
+bin/stanc:
+	@mkdir -p $(dir $@)
+	curl -L https://$(URL)/$(STAN_VERSION)/$(OS_TAG)-stanc -o $@
+	chmod +x $@

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+help: ## First target is the default make target
+
+
 PHONY: help all install uninstall clean check
 
 STAN_VERSION=v2.29.0-rc2
@@ -5,6 +8,7 @@ STAN_VERSION=v2.29.0-rc2
 help:
 	@echo '--------------------------------------------------------------------------------'
 	@echo '--------------------------------------------------------------------------------'
+
 
 all:
 	@echo 'all'


### PR DESCRIPTION
This PR does a few things for setting up:

1. Adds a `Makefile` to help coordinate setup and build
2. Creates some standard "targets." See: https://www.gnu.org/prep/standards/html_node/Standard-Targets.html
3. The high-level target for now is `make install`. 
    1. This will download an appropriate `bin/stanc` and make it executable
    2. This will update the Stan submodule
    3. This will update the Stan Math submodule
4. `make check` will check if these three things have been done.
5. `make clean` does nothing now
6. `make uninstall` will remove `bin/stanc`

I'm sure everything here can be done better. The goal was to get something going so we can focus on the rest first. If you think there are immediate ways of improvement, please suggest them.