### PR TITLE
Create build rules using `make`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /bin/stanc
 /bin/stanc.exe
 
-
+*.o
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ PHONY: help all install uninstall clean check
 STAN_VERSION = v2.29.0-rc2
 STANCFLAGS ?= --warn-pedantic
 
+CXXFLAGS = -I stan/src -I stan/lib/stan_math
+CXXFLAGS += -I stan/lib/stan_math/lib/eigen_3.3.9 -I stan/lib/stan_math/lib/boost_1.75.0
+CXXFLAGS += -I stan/lib/stan_math/lib/sundials_6.0.0/include -I stan/lib/stan_math/lib/tbb_2020.3/include
+CXXFLAGS += -std=c++14
+CXXFLAGS += -D_REENTRANT
+
 help:
 	@echo '--------------------------------------------------------------------------------'
 	@echo '--------------------------------------------------------------------------------'
@@ -55,5 +61,7 @@ stan/src/stan/version.hpp:
 stan/lib/stan_math/stan/math/version.hpp: stan/src/stan/version.hpp
 	cd stan && git submodule update --init --depth 1
 
-%.hpp: %.stan bin/stanc
+%.cpp: %.stan bin/stanc
 	bin/stanc $< --o $@
+
+

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CXXFLAGS += -I stan/lib/stan_math/lib/eigen_3.3.9 -I stan/lib/stan_math/lib/boos
 CXXFLAGS += -I stan/lib/stan_math/lib/sundials_6.0.0/include -I stan/lib/stan_math/lib/tbb_2020.3/include
 CXXFLAGS += -std=c++14
 CXXFLAGS += -D_REENTRANT
+CXXFLAGS += -O3
 
 help:
 	@echo '--------------------------------------------------------------------------------'

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ stan/src/stan/version.hpp:
 stan/lib/stan_math/stan/math/version.hpp: stan/src/stan/version.hpp
 	cd stan && git submodule update --init --depth 1
 
-%.cpp: %.stan bin/stanc
+%.cpp: %.stan bin/stanc src/main.o
 	bin/stanc $< --o $@
 
 $(MATH)/lib/tbb/lib%.dylib: LIB = $(patsubst $(MATH)/%,%,$@)

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,6 @@ help:
 all:
 	@echo 'all'
 
-#ifeq ($(OS),Darwin)
-#  TBB_LIBRARIES ?= tbb tbbmalloc tbbmalloc_proxy
-#else
-#  TBB_LIBRARIES ?= tbb
-#endif
-
 install: bin/stanc stan/src/stan/version.hpp $(MATH)/stan/math/version.hpp src/main.o
 install: $(TBB_LIBRARIES)
 install:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ CXXFLAGS += -std=c++14
 CXXFLAGS += -D_REENTRANT
 CXXFLAGS += -O3
 
-LDLIBS = src/main.o
 
 MATH := stan/lib/stan_math
 
@@ -22,6 +21,8 @@ OS_TAG ?= $(strip $(if $(filter Darwin,$(OS)), mac, linux))
 TBB_LIBRARIES = $(if $(filter linux,$(OS_TAG)),tbb,tbb tbbmalloc tbbmalloc_proxy)
 TBB_LIBRARIES := $(TBB_LIBRARIES:%=$(MATH)/lib/tbb/lib%.dylib)
 
+LDLIBS = src/main.o $(TBB_LIBRARIES) -Wl,-L,$(MATH)/lib/tbb -Wl,-rpath,$(MATH)/lib/tbb
+LINK.o = $(LINK.cpp)
 
 help:
 	@echo '--------------------------------------------------------------------------------'
@@ -42,10 +43,6 @@ install: $(TBB_LIBRARIES)
 install:
 	@echo
 	@echo 'Installation complete'
-
-$(MATH)/lib/tbb/lib%.dylib: LIB = $(patsubst $(MATH)/%,%,$@)
-$(MATH)/lib/tbb/lib%.dylib: $(MATH)/stan/math/version.hpp
-	$(MAKE) -C $(MATH) $(LIB)
 
 uninstall:
 	$(RM) bin/stanc
@@ -85,3 +82,8 @@ stan/lib/stan_math/stan/math/version.hpp: stan/src/stan/version.hpp
 
 %.cpp: %.stan bin/stanc
 	bin/stanc $< --o $@
+
+$(MATH)/lib/tbb/lib%.dylib: LIB = $(patsubst $(MATH)/%,%,$@)
+$(MATH)/lib/tbb/lib%.dylib: $(MATH)/stan/math/version.hpp
+	$(MAKE) -C $(MATH) $(LIB)
+

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ MATH := stan/lib/stan_math
 
 OS ?= $(shell uname -s)
 OS_TAG ?= $(strip $(if $(filter Darwin,$(OS)), mac, linux))
+LIBRARY_SUFFIX = $(if $(filter linux,$(OS_TAG)),so.2,dylib)
 TBB_LIBRARIES = $(if $(filter linux,$(OS_TAG)),tbb,tbb tbbmalloc tbbmalloc_proxy)
-TBB_LIBRARIES := $(TBB_LIBRARIES:%=$(MATH)/lib/tbb/lib%.dylib)
+TBB_LIBRARIES := $(TBB_LIBRARIES:%=$(MATH)/lib/tbb/lib%.$(LIBRARY_SUFFIX))
 
 LDLIBS = src/main.o $(TBB_LIBRARIES) -Wl,-L,$(MATH)/lib/tbb -Wl,-rpath,$(MATH)/lib/tbb
 LINK.o = $(LINK.cpp)
@@ -83,7 +84,7 @@ stan/lib/stan_math/stan/math/version.hpp: stan/src/stan/version.hpp
 %.cpp: %.stan bin/stanc src/main.o
 	bin/stanc $< --o $@
 
-$(MATH)/lib/tbb/lib%.dylib: LIB = $(patsubst $(MATH)/%,%,$@)
-$(MATH)/lib/tbb/lib%.dylib: $(MATH)/stan/math/version.hpp
+$(MATH)/lib/tbb/lib%: LIB = $(patsubst $(MATH)/%,%,$@)
+$(MATH)/lib/tbb/lib%: $(MATH)/stan/math/version.hpp
 	$(MAKE) -C $(MATH) $(LIB)
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ help: ## First target is the default make target
 
 PHONY: help all install uninstall clean check
 
-STAN_VERSION=v2.29.0-rc2
+STAN_VERSION = v2.29.0-rc2
+STANCFLAGS ?= --warn-pedantic
 
 help:
 	@echo '--------------------------------------------------------------------------------'
@@ -53,3 +54,6 @@ stan/src/stan/version.hpp:
 
 stan/lib/stan_math/stan/math/version.hpp: stan/src/stan/version.hpp
 	cd stan && git submodule update --init --depth 1
+
+%.hpp: %.stan bin/stanc
+	bin/stanc $< --o $@

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,9 @@ clean:
 
 check:
 	@ n=0; \
-	test -f bin/stanc || { echo 'Error: bin/stanc does not exist'; ((n++)); } ; \
-	test -f stan/src/stan/version.hpp || { echo 'Error: Stan submodule needs to be updated'; ((n++)); }; \
-	test -f stan/lib/stan_math/stan/math/version.hpp || { echo 'Error: Stan Math submodule needs to be updated'; ((n++)); }; \
+	test -f bin/stanc || { echo 'Error: bin/stanc does not exist'; ((n++)); } && echo '* bin/stanc ok' ; \
+	test -f stan/src/stan/version.hpp || { echo 'Error: Stan submodule needs to be updated'; ((n++)); } && echo '* Stan submodule ok' ; \
+	test -f stan/lib/stan_math/stan/math/version.hpp || { echo 'Error: Stan Math submodule needs to be updated'; ((n++)); } && echo '* Stan Math submodule ok' ; \
 	if [ $$n -gt 0 ]; then echo; echo 'Please run `make install`'; echo; exit 1; fi
 	@echo
 	@echo 'Check: All checks pass'

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+  std::cout << "inside main" << std::endl << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This PR adds rules to the Makefile that will enable building an executable from a Stan file. This should work on both Linux and Mac.

Rules added to the Makefile:
- Generate `.cpp` from `.stan` file
- Create TBB libraries by using the Stan Math makefiles
- Changed `LINK.o` make variable to `LINK.cpp` to enable the correct linker.
- Updated `install` target to also require the TBB libraries

This allows an executable to be created and runable.

I didn't include an example in the code, but as an example, you can copy any `.stan` program into the working directory. Let's call it `model.stan` for example. We should be able to install it by typing:

1. `make install`. This will install `bin/stanc`, get the submodules, build the TBB libraries, and build `src/main.o` from `src/main.cpp`.
2. `make model`. This will build the `model` executable by first generating the `.cpp` file from `.stan` file, compile a `.o` from the `.cpp` file, then linking it all together into an executable.

Note: if we get fancy, we could load the library dynamically at runtime instead of creating a new executable.